### PR TITLE
Support For Libraries Webserver MariaDB Database Config Vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ module "db" {
 | subnet\_ids | List of subnets for the DB | `list(string)` | n/a | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
 | vpc\_id | VPC ID the DB instance will be created in | `string` | n/a | yes |
+| deletion\_protection | Protect this database instance from deletion | `string` | false | no |
+| enabled\_cloudwatch\_logs\_exports | List of logs to export to AWS CloudWatch | `list` | n/a | no |
+| monitoring\_interval | Interval to monitor the RDS instance | `string` | 0 | no |
+
 ## Outputs
 
 | Name | Description |

--- a/main.tf
+++ b/main.tf
@@ -16,37 +16,40 @@ module "final_snapshot_label" {
 }
 
 resource "aws_db_instance" "default" {
-  count                       = var.enabled == "true" ? 1 : 0
-  identifier                  = module.label.name
-  name                        = var.database_name
-  username                    = var.database_user
-  password                    = var.database_password
-  port                        = var.database_port
-  engine                      = var.engine
-  engine_version              = var.engine_version
-  instance_class              = var.instance_class
-  allocated_storage           = var.allocated_storage
-  storage_encrypted           = var.storage_encrypted
-  vpc_security_group_ids      = [join("", aws_security_group.default.*.id)]
-  db_subnet_group_name        = join("", aws_db_subnet_group.default.*.name)
-  parameter_group_name        = length(var.parameter_group_name) > 0 ? var.parameter_group_name : join("", aws_db_parameter_group.default.*.name)
-  option_group_name           = length(var.option_group_name) > 0 ? var.option_group_name : join("", aws_db_option_group.default.*.name)
-  license_model               = var.license_model
-  multi_az                    = var.multi_az
-  storage_type                = var.storage_type
-  iops                        = var.iops
-  publicly_accessible         = var.publicly_accessible
-  snapshot_identifier         = var.snapshot_identifier
-  allow_major_version_upgrade = var.allow_major_version_upgrade
-  auto_minor_version_upgrade  = var.auto_minor_version_upgrade
-  apply_immediately           = var.apply_immediately
-  maintenance_window          = var.maintenance_window
-  skip_final_snapshot         = var.skip_final_snapshot
-  copy_tags_to_snapshot       = var.copy_tags_to_snapshot
-  backup_retention_period     = var.backup_retention_period
-  backup_window               = var.backup_window
-  tags                        = module.label.tags
-  final_snapshot_identifier   = length(var.final_snapshot_identifier) > 0 ? var.final_snapshot_identifier : module.final_snapshot_label.name
+  count                           = var.enabled == "true" ? 1 : 0
+  identifier                      = module.label.name
+  name                            = var.database_name
+  username                        = var.database_user
+  password                        = var.database_password
+  port                            = var.database_port
+  engine                          = var.engine
+  engine_version                  = var.engine_version
+  instance_class                  = var.instance_class
+  allocated_storage               = var.allocated_storage
+  storage_encrypted               = var.storage_encrypted
+  vpc_security_group_ids          = [join("", aws_security_group.default.*.id)]
+  db_subnet_group_name            = join("", aws_db_subnet_group.default.*.name)
+  parameter_group_name            = length(var.parameter_group_name) > 0 ? var.parameter_group_name : join("", aws_db_parameter_group.default.*.name)
+  option_group_name               = length(var.option_group_name) > 0 ? var.option_group_name : join("", aws_db_option_group.default.*.name)
+  license_model                   = var.license_model
+  multi_az                        = var.multi_az
+  storage_type                    = var.storage_type
+  iops                            = var.iops
+  publicly_accessible             = var.publicly_accessible
+  snapshot_identifier             = var.snapshot_identifier
+  allow_major_version_upgrade     = var.allow_major_version_upgrade
+  auto_minor_version_upgrade      = var.auto_minor_version_upgrade
+  apply_immediately               = var.apply_immediately
+  maintenance_window              = var.maintenance_window
+  skip_final_snapshot             = var.skip_final_snapshot
+  copy_tags_to_snapshot           = var.copy_tags_to_snapshot
+  backup_retention_period         = var.backup_retention_period
+  backup_window                   = var.backup_window
+  deletion_protection             = var.deletion_protection
+  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
+  monitoring_interval             = var.monitoring_interval
+  tags                            = module.label.tags
+  final_snapshot_identifier       = length(var.final_snapshot_identifier) > 0 ? var.final_snapshot_identifier : module.final_snapshot_label.name
 }
 
 resource "aws_db_parameter_group" "default" {
@@ -132,4 +135,3 @@ resource "aws_route53_record" "default" {
   records = aws_db_instance.default.*.address
   count   = var.enabled == "true" ? 1 : 0
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -244,3 +244,20 @@ variable "option_group_name" {
   default     = ""
 }
 
+variable "deletion_protection" {
+  type        = string
+  description = "Protect this database instance from deletion"
+  default     = "false"
+}
+
+variable "enabled_cloudwatch_logs_exports" {
+  type        = list(string)
+  description = "List of logs to export to AWS CloudWatch"
+  default     = []
+}
+
+variable "monitoring_interval" {
+  type        = string
+  description = "Interval to monitor the RDS instance"
+  default     = "0"
+}


### PR DESCRIPTION
Why these changes are being introduced:

The Libraries webserver MariaDB database uses some additional configuration options that the Libraries RDS database module does not currently support passing. This code allows those additional vars to be passed in. If they are not, Terraform attempts to set the values for these options back to the module default (disabled). That causes us to see undesired changes when running `terraform plan` and would result in undesirable changes if the module driven changes were allowed to be applied during a `terraform apply`.

How this addresses that need:
* additional variables added to the vars file
* setting of module options with those passed in variables in the main.tf file

Side effects of this change:
None. I made sure that if these variables are not passed in, the old defaults
(disabled) are still applied.

Changes to be committed:
       modified:   README.md
       modified:   main.tf
       modified:   variables.tf

#### Developer Checklist

- [X] The README contains the correct list of dependencies, inputs, and outputs (e.g., `terraform-docs markdown .` has been run)

#### What does this PR do?

See above.

#### Helpful background context

I need this code merged so that I can complete the v0.13 upgrade of the webserver code. Specifically, this is because additional features were enabled through the console rather than with terraform (Cloudwatch, Deletion Protection, and Monitoring). Since this is just simple additional variable passing code, I don't believe that you actually need to run it to review it. It's very simple and straight forward. However, if you want to, you can run it locally from your machine by modifying the terraform  libraries-website app code that loads it as following:

module "db" {
#  source                      = "github.com/mitlibraries/tf-mod-rds?ref=0.13"
  source                      = "/home/vab/devl/libraries-ws-upgrade/tf-mod-rds-0.13"

You would also need to manually modify the code to match what is currently running in AWS as I haven't committed the code that changes the database configurations in the libraries-website code from hard coded to vars from the tfvars file. If you do want to run this code before you approve the PR, I suggest you wait until I push my 0.13 branch against the terraform repository and just pull that done. I will try and do that later today, or by Monday morning.

I have already run this code (a v0.12 backport version) against stage and production to upgrade the tfstate files from v0.11 to v0.12 for the library-website app.

#### What are the relevant tickets?

https://mitlibraries.atlassian.net/browse/IN-272

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
